### PR TITLE
Update README - Required properties, Output

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ Resources:
     Type: 'AWSUtility::CloudFormation::CommandRunner'
     Properties:
       Command: aws s3 ls | sed -n 1p | cut -d " " -f3 > /command-output.txt
-      Role: String #Optional
-      LogGroup: String #Optional
+      Role: String #Required
+      LogGroup: String #Required
       SubnetId: String #Optional
       SecurityGroupId: String #Optional
       KeyId: String #Optional
@@ -74,7 +74,7 @@ Resources:
 Outputs:
     Output:
         Description: The output of the CommandRunner.
-        Value: !GetAtt Command.Output
+        Value: !GetAtt CommandRunner.Output
 ```
 *Note: In the above example, `sed -n 1p` prints only the first line from the response returned by `aws s3 ls`. To get the bucket name, `sed -n 1p` pipes the response to `cut -d " " -f3`, which chooses the third element in the array created after splitting the line delimited by a space.*
 


### PR DESCRIPTION
After installing successfully and creating a CommandRunner command in Cloudformation with just the Command property I kept getting errors like `Either the command failed to execute, the value written to /command-output.txt was invalid or the Subnet specified did not have internet access.`
- I had to add Role and LogGroup properties as well. So I think these are required.
- Also output value of the command only worked when I changed it to CommandRunner, I guess it is looking for a resource name. 
Great plugin! Hope it becomes a standard Cloudformation Type

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
