### PR TITLE
Better region determination in register.sh

### DIFF
--- a/scripts/register.sh
+++ b/scripts/register.sh
@@ -3,7 +3,7 @@
 #  exit
 #fi
 
-region=`aws configure get region`
+region=`aws ec2 describe-availability-zones --output text --query 'AvailabilityZones[0].[RegionName]'`
 if [ -z "$region" ]; then
   echo "No region configured, please configure a default region using aws configure."
   exit


### PR DESCRIPTION
*Description of changes:*

- I tried running `register.sh` in an AWS CloudShell instance and was getting the error "No region configured, please configure a default region using aws configure."
- This led me to dig into register.sh and I found there is a more robust method of determining current region
- I changed `aws configure get region` to `aws ec2 describe-availability-zones --output text --query 'AvailabilityZones[0].[RegionName]'`
- I have tested from AWS CloudShell and my local machine and both are working


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
