### PR TITLE
Fix IAM policy

### DIFF
--- a/resource-role.yaml
+++ b/resource-role.yaml
@@ -47,7 +47,7 @@ Resources:
                 - "kms:Encrypt"
                 - "logs:CreateLogStream"
                 - "logs:DescribeLogGroups"
-                - "log:PutLogEvents"
+                - "logs:PutLogEvents"
                 - "cloudwatch:PutMetricData"
                 - "ssm:DeleteParameter"
                 - "ssm:GetParameter"


### PR DESCRIPTION
*Description of changes:*
The IAM policy for the CommandRunner role includes a reference to `log:` which is not a correct identifier for CloudWatch logs; it should be `logs:`. This PR addresses that. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
